### PR TITLE
Update gm_handshake_server.go

### DIFF
--- a/tls/gm_handshake_server.go
+++ b/tls/gm_handshake_server.go
@@ -386,7 +386,7 @@ func (hs *serverHandshakeStateGM) doFullHandshake() error {
 	}
 
 	keyAgreement := hs.suite.ka(c.vers)
-	skx, err := keyAgreement.generateServerKeyExchange(c.config, hs.cert, hs.clientHello, hs.hello)
+	skx, err := keyAgreement.generateServerKeyExchange(c.config, hs.cert, hs.cert, hs.clientHello, hs.hello)
 	if err != nil {
 		c.sendAlert(alertHandshakeFailure)
 		return err


### PR DESCRIPTION
修复单证书模式下generateServerKeyExchange参数缺少问题