### PR TITLE
repair -- handshake error : tls: first record does not look like a TL…

### DIFF
--- a/tls/gm_handshake_client.go
+++ b/tls/gm_handshake_client.go
@@ -320,7 +320,7 @@ func (hs *clientHandshakeStateGM) doFullHandshake() error {
 		certRequested = true
 		hs.finishedHash.Write(certReq.marshal())
 
-		if chainToSend, err = hs.getCertificate(certReq); err != nil || chainToSend.Certificate == nil {
+		if chainToSend, err = hs.getCertificate(certReq); err != nil{
 			c.sendAlert(alertInternalError)
 			return err
 		}

--- a/tls/gm_handshake_client_double.go
+++ b/tls/gm_handshake_client_double.go
@@ -313,7 +313,7 @@ func (hs *clientHandshakeStateGM) doFullHandshake() error {
 		certRequested = true
 		hs.finishedHash.Write(certReq.marshal())
 
-		if chainToSend, err = hs.getCertificate(certReq); err != nil || chainToSend.Certificate == nil {
+		if chainToSend, err = hs.getCertificate(certReq); err != nil{
 			c.sendAlert(alertInternalError)
 			return err
 		}


### PR DESCRIPTION
…S handshake
修复bug如下 : @suchongming 这个bug之前有和你反馈讨论过，麻烦当初看看添加这个限制原因。
andshake error : tls: first record does not look like a TLS handshake
handshake error : tls: first record does not look like a TLS handshake
handshake error : tls: first record does not look like a TLS handshake
Error: failed to create deliver client for orderer: orderer client failed to connect to localhost:7050: failed to create new connection: context deadline exceeded
!!!!!!!!!!!!!!! Channel creation failed !!!!!!!!!!!!!!!!
Error !!! Create channel failed

Signed-off-by: 陈桂军 <chengj16@bngrp.com>