### PR TITLE
fix the bug that pemDecrypt does not check the validity of padLength

### DIFF
--- a/x509/pem_decrypt.go
+++ b/x509/pem_decrypt.go
@@ -43,7 +43,6 @@ const (
  * reference to RFC5959 and RFC2898
  */
 
-
 var (
 	oidPBES1  = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 3}  // pbeWithMD5AndDES-CBC(PBES1)
 	oidPBES2  = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 13} // id-PBES2(PBES2)
@@ -233,14 +232,17 @@ func DecryptPEMBlock(b *pem.Block, password []byte) ([]byte, error) {
 
 	//un-padding
 	dataLen := len(encryptedKey)
-	padLen := int(encryptedKey[dataLen - 1])
+	padLen := int(encryptedKey[dataLen-1])
+	//check the padLen
+	if dataLen <= padLen {
+		return nil, errors.New("padding info incorrect")
+	}
 	for i := 0; i < padLen; i++ {
-		if int(encryptedKey[dataLen - padLen + i]) != padLen {
+		if int(encryptedKey[dataLen-padLen+i]) != padLen {
 			return nil, errors.New("padding info incorrect")
 		}
 	}
-
-	return encryptedKey[:dataLen - padLen], nil
+	return encryptedKey[:dataLen-padLen], nil
 }
 
 // EncryptPEMBlock returns a PEM block of the specified type holding the

--- a/x509/pem_decrypt_test.go
+++ b/x509/pem_decrypt_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/base64"
-	"github.com/Hyperledger-TWGC/ccs-gm/sm2"
 	"testing"
+
+	"github.com/Hyperledger-TWGC/ccs-gm/sm2"
 )
 
 func TestEncAndDecPem(t *testing.T) {
@@ -35,6 +36,16 @@ func TestEncAndDecPem(t *testing.T) {
 	}
 	if !bytes.Equal([]byte(plainDer), privKey) {
 		t.Error("decrypt pem invalid!")
+		return
+	}
+	//decrypt with wrong passwd
+	_, err = DecryptPEMBlock(block, []byte("abcd"))
+	if err == nil {
+		t.Error("decrypt couldn't success")
+		return
+	}
+	if err.Error() != "padding info incorrect" {
+		t.Errorf("unexpected error, expect \"padding info incorrect\",\n actually is \"%s\"", err)
 		return
 	}
 }


### PR DESCRIPTION
If I decrypt a PEMBlcok with the wrong passwd, the padding of the last byte at the end will probably be incorrect. If the read padLength is greater than the dataLength, the following array index will be negative, resulting in a "index out of range" bug. To modify the method, you only need to add a judgment to it. In addition, I have added a test for this situation to the test.